### PR TITLE
Fix for Java-based GUI

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1,4 +1,4 @@
-/** 
+/**
  * Debug support
  */
 
@@ -23,12 +23,12 @@ int jailbreak_device(const char *uuid);
 #undef DEBUG
 
 #define DEBUG(x...) \
- 	printf("[debug] "), printf(x)
+{ printf("[debug] "), printf(x); fflush(stdout); }
 
 #define ERROR(x...) \
- 	do { printf("[error] "), printf(x), exit(-1); } while(0);
+do { printf("[error] "), printf(x); fflush(stdout); exit(-1); } while(0);
 
 #define WARN(x...) \
- 	printf("[warn] "), printf(x)
+{ printf("[warn] "), printf(x); fflush(stdout); }
 
 #endif

--- a/src/jailbreak.c
+++ b/src/jailbreak.c
@@ -714,7 +714,7 @@ void stroke_lockdownd(device_t * device)
     size = __builtin_bswap32(size);
     if (size) {
         void *ptr = malloc(size);
-        idevice_connection_receive_timeout(connection, ptr, &size, &sent, 5000);
+        idevice_connection_receive_timeout(connection, ptr, size, &sent, 5000);
     }
     idevice_disconnect(connection);
 


### PR DESCRIPTION
Simply flushes the output after every write to the console.
Works well without causing performance issues, and doesn't affect the console in any way as it ends up flushing an empty buffer.